### PR TITLE
Add placeholders for empty slots and tweak waitlist

### DIFF
--- a/__tests__/core-functionality.test.ts
+++ b/__tests__/core-functionality.test.ts
@@ -19,7 +19,7 @@ describe("Core Bot Functionality Tests", () => {
 Записавшиеся игроки:
 
 ⏳ Waitlist:
-_Пусто_`;
+---`;
 
       const result = MessageUtils.updateMessageWithUserSelection(
         messageWithoutHTML,
@@ -101,7 +101,7 @@ _Пусто_`;
       const emptyGameMessage = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const result = MessageUtils.updateMessageWithUserSelection(
         emptyGameMessage,
@@ -117,7 +117,7 @@ _Пусто_`;
       let currentMessage = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       // Add 3 players
       for (let i = 1; i <= 3; i++) {
@@ -140,13 +140,13 @@ _Пусто_`;
         `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`,
+---`,
         "@player",
         "D"
       );
 
       expect(result.updatedMessage).toContain("⏳ <b>Waitlist:</b>");
-      expect(result.updatedMessage).toContain("_Пусто_");
+      expect(result.updatedMessage).toContain("---");
     });
 
     test("should handle player cancellation from main list", () => {
@@ -157,7 +157,7 @@ _Пусто_`,
 3. @player3 (D+)
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       // Cancel player2
       const result = MessageUtils.updateMessageWithUserSelection(
@@ -234,7 +234,7 @@ _Пусто_`;
       const message = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const specialUsernames = [
         "@тест_user",
@@ -260,7 +260,7 @@ _Пусто_`;
       const message = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const startTime = Date.now();
 
@@ -281,7 +281,7 @@ _Пусто_`;
 💵 Цена: 65 aed/чел
 Записавшиеся игроки:
 ⏳ Waitlist:
-_Пусто_`;
+---`;
 
       const startTime = Date.now();
 
@@ -316,7 +316,7 @@ _Пусто_`;
 1. @player1 (D+)
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
     test("should parse game time correctly", () => {
       const tomorrow = new Date();
@@ -441,7 +441,7 @@ _Пусто_`;
 2. @player2 (D)
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const cancelledMessage = MessageUtils.cancelGame(gameMessage);
 
@@ -467,7 +467,7 @@ _Пусто_`;
 1. @player1 (D+)
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const restoredMessage = MessageUtils.restoreGame(cancelledMessage);
 
@@ -503,7 +503,7 @@ _Пусто_`;
 <b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const stats = MessageUtils.getGameStats(emptyGameMessage);
 

--- a/__tests__/example-simple.test.ts
+++ b/__tests__/example-simple.test.ts
@@ -16,7 +16,7 @@ describe("Example Tests - Simple Working Tests", () => {
 Записавшиеся игроки:
 
 ⏳ Waitlist:
-_Пусто_`;
+---`;
 
       const result = MessageUtils.updateMessageWithUserSelection(
         messageWithoutHTML,
@@ -51,7 +51,7 @@ _Пусто_`;
       const emptyGameMessage = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const result = MessageUtils.updateMessageWithUserSelection(
         emptyGameMessage,
@@ -70,7 +70,7 @@ _Пусто_`;
 2. @player2 (D)
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const result = MessageUtils.updateMessageWithUserSelection(
         gameWithPlayers,
@@ -138,7 +138,7 @@ _Пусто_`;
       const message = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const result = MessageUtils.updateMessageWithUserSelection(
         message,
@@ -155,7 +155,7 @@ _Пусто_`;
       const message = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const startTime = Date.now();
 

--- a/__tests__/integration-workflow.test.ts
+++ b/__tests__/integration-workflow.test.ts
@@ -16,7 +16,7 @@ describe("Integration Tests - Complete Workflows", () => {
 Записавшиеся игроки:
 
 ⏳ Waitlist:
-_Пусто_`;
+---`;
 
       // Test first player registration
       const result1 = MessageUtils.updateMessageWithUserSelection(
@@ -59,7 +59,7 @@ _Пусто_`;
       );
 
       expect(waitlistResult.updatedMessage).toContain("🎾 @waitlist1 (D+)");
-      expect(waitlistResult.updatedMessage).not.toContain("_Пусто_");
+      expect(waitlistResult.updatedMessage).not.toContain("---");
       expect(waitlistResult.notification).toBeUndefined();
 
       // Verify HTML formatting is preserved throughout
@@ -140,7 +140,7 @@ _Пусто_`;
       const baseMessage = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       const startTime = Date.now();
 
@@ -171,7 +171,7 @@ _Пусто_`;
 📍 Место: SANDDUNE PADEL CLUB Al Qouz
 Записавшиеся игроки:
 ⏳ Waitlist:
-_Пусто_`;
+---`;
 
       const startTime = Date.now();
 
@@ -226,7 +226,7 @@ _Пусто_`;
       const message = `<b>Записавшиеся игроки:</b>
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       specialUsernames.forEach((username) => {
         const result = MessageUtils.updateMessageWithUserSelection(
@@ -262,7 +262,7 @@ _Пусто_`;
 1. @player1 (D+)
 
 ⏳ <b>Waitlist:</b>
-_Пусто_`;
+---`;
 
       // Test penalty detection
       const lateCancellationCheck =

--- a/src/app/lib/telegram/constants.ts
+++ b/src/app/lib/telegram/constants.ts
@@ -124,7 +124,11 @@ export const GAME_MESSAGE_TEMPLATE = (gameInfo: {
 
 📅 <a href="${calendar.google}">Добавить в Google Calendar</a>
 
-${gameInfo.cancelled ? "Игра отменена. Waitlist:" : "Записавшиеся игроки:"}`;
+${gameInfo.cancelled ? "Игра отменена. Waitlist:" : "Записавшиеся игроки:"}
+${Array.from({ length: gameInfo.courts * 4 }, (_, i) => `${i + 1}. -`).join("\n")}
+
+⏳ <b>Waitlist:</b>
+---`;
 };
 
 export const CALLBACK_MESSAGES = {

--- a/src/app/lib/telegram/message-utils.ts
+++ b/src/app/lib/telegram/message-utils.ts
@@ -311,6 +311,20 @@ export class MessageUtils {
   }
 
   /**
+   * Parses the number of courts from the base message text
+   */
+  private static getCourtsFromMessage(text: string): number {
+    const match = text.match(/Забронировано кортов:(?:<\/b>)?\s*(\d+)/);
+    if (match) {
+      const parsed = parseInt(match[1], 10);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return 1; // default if not found
+  }
+
+  /**
    * Builds the updated message with user registrations and waitlist
    */
   private static buildUpdatedMessageWithWaitlist(
@@ -319,15 +333,19 @@ export class MessageUtils {
     waitlist: Map<string, { displayName: string; level: string }>
   ): string {
     let updatedMessage = baseMessage;
+    const courts = this.getCourtsFromMessage(baseMessage);
+    const maxPlayers = courts * 4;
 
-    // Add main players (max 4)
-    if (registrations.size > 0) {
-      updatedMessage += "\n";
-      let counter = 1;
-      for (const { displayName, level } of registrations.values()) {
-        updatedMessage += `\n${counter}. ${displayName} (${level})`;
-        counter++;
-      }
+    updatedMessage += "\n";
+    let counter = 1;
+    for (const { displayName, level } of registrations.values()) {
+      updatedMessage += `\n${counter}. ${displayName} (${level})`;
+      counter++;
+    }
+
+    // Fill remaining slots with placeholders
+    for (let i = counter; i <= maxPlayers; i++) {
+      updatedMessage += `\n${i}. -`;
     }
 
     // Add waitlist section (always show, even if empty)
@@ -337,7 +355,7 @@ export class MessageUtils {
         updatedMessage += `\n🎾 ${displayName} (${level})`;
       }
     } else {
-      updatedMessage += "\n_Пусто_";
+      updatedMessage += "\n---";
     }
 
     return updatedMessage;


### PR DESCRIPTION
## Summary
- show placeholder slots in game messages
- change empty waitlist text to dashes
- parse court count from message when updating
- adjust tests for new placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b99396a5883259b2e6740775d93d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Player lists now dynamically display numbered slots based on the number of courts, with empty slots shown as dashes.
  * The waitlist section now uses "---" as the placeholder when empty, instead of the previous text.

* **Tests**
  * Updated test cases to reflect the new waitlist placeholder and dynamic player slot formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->